### PR TITLE
actually feed pytom particle_diameter

### DIFF
--- a/batch_pytom_aretomo3.py
+++ b/batch_pytom_aretomo3.py
@@ -194,6 +194,8 @@ def make_sbatch(prefix, tlt, df, exp, args):
         # optional args, only if set
         if args.angular_search:
             f.write(f"  --angular-search {args.angular_search} \\\n")
+        if args.particle_diameter:
+            f.write(f"  --particle_diameter {args.particle_diameter} \\\n")
         if args.volume_split:
             x,y,z = args.volume_split
             f.write(f"  -s {x} {y} {z} \\\n")


### PR DESCRIPTION
Thanks for this great script.
While running a colleague of mine ran into the issue that the `--particle-diameter` option wasn't put in the pytom command. This fixes that 